### PR TITLE
Updating Autocomplete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peopledatalabs"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "A Rust client for the People Data Labs API"
 documentation = "https://docs.peopledatalabs.com/docs/rust-sdk"

--- a/src/models/autocomplete.rs
+++ b/src/models/autocomplete.rs
@@ -13,9 +13,6 @@ pub struct AutocompleteBaseParams {
     /// Setting titlecase to true will titlecase the data in 200 responses
     #[serde(rename = "titlecase", skip_serializing_if = "Option::is_none")]
     pub titlecase: Option<bool>,
-    /// Setting beta to true will enable the beta autocomplete endpoint
-    #[serde(rename = "beta", skip_serializing_if = "Option::is_none")]
-    pub beta: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
### Description

This PR removes the `beta` field from the Autocomplete parameter options.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
