### PR TITLE
SearchPersonResponse make scroll_token optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peopledatalabs"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 description = "A Rust client for the People Data Labs API"
 documentation = "https://docs.peopledatalabs.com/docs/rust-sdk"

--- a/src/api/person.rs
+++ b/src/api/person.rs
@@ -301,6 +301,7 @@ mod tests {
         assert_eq!(resp.status, 200);
         assert_eq!(resp.data.unwrap().len(), num_results);
         assert_eq!(resp.scroll_token.is_empty(), false);
+        assert_eq!(resp.scroll_token.is_some() && !resp.scroll_token.as_ref().unwrap().is_empty(), true);
     }
 
     #[test]

--- a/src/api/person.rs
+++ b/src/api/person.rs
@@ -300,7 +300,6 @@ mod tests {
 
         assert_eq!(resp.status, 200);
         assert_eq!(resp.data.unwrap().len(), num_results);
-        assert_eq!(resp.scroll_token.is_empty(), false);
         assert_eq!(resp.scroll_token.is_some() && !resp.scroll_token.as_ref().unwrap().is_empty(), true);
     }
 

--- a/src/models/person.rs
+++ b/src/models/person.rs
@@ -363,7 +363,7 @@ pub struct SearchPersonResponse {
 
     pub data: Option<Vec<Person>>,
     pub total: i32,
-    pub scroll_token: String,
+    pub scroll_token: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Description of the change

The response from the API, in the event of an error, does not contain a scroll token. This causes a failure to deserialize when an error response is received. By making the scroll token optional you are able to use the SearchPersonResponse to handle success and error cases.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
