### PR TITLE
Add Updated Title Roles to Autocomplete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peopledatalabs"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 description = "A Rust client for the People Data Labs API"
 documentation = "https://docs.peopledatalabs.com/docs/rust-sdk"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://i.imgur.com/S7DkZtr.png" width="250" alt="People Data Labs Logo">
+<img src="https://www.peopledatalabs.com/images/company-logo.png" style="background-color: white; padding: 5px 10px;" width="250" alt="People Data Labs Logo">
 </p>
 <h1 align="center">People Data Labs Rust Client</h1>
 <p align="center">Official Rust client for the People Data Labs API.</p>

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ let results = client.skill.get(params);
 
 ```rust
 let mut ip_base_params = IPBaseParams::default();
-ip_base_params.ip = Some("72.212.42.169".to_string());
+ip_base_params.ip = Some("72.212.42.228".to_string());
 let params = IPParams {
     base_params: None,
     ip_base_params,

--- a/examples/autocompete/main.rs
+++ b/examples/autocompete/main.rs
@@ -6,6 +6,7 @@ fn main() {
         field: "text".to_string(),
         text: Some("full".to_string()),
         titlecase: Some(false),
+        updated_title_roles: Some(false),
     };
     let autocomplete_params = AutocompleteParams {
         base_params: None,

--- a/examples/ip/main.rs
+++ b/examples/ip/main.rs
@@ -3,7 +3,7 @@ use peopledatalabs::{IPBaseParams, IPParams, PDL};
 fn main() {
     let client = PDL::new();
     let mut ip_base_params = IPBaseParams::default();
-    ip_base_params.ip = Some("72.212.42.169".to_string());
+    ip_base_params.ip = Some("72.212.42.228".to_string());
     let params = IPParams {
         base_params: None,
         ip_base_params,

--- a/src/api/autocomplete.rs
+++ b/src/api/autocomplete.rs
@@ -45,6 +45,7 @@ mod tests {
             field: "school".to_string(),
             text: Some("stanf".to_string()),
             titlecase: Some(false),
+            updated_title_roles: Some(false),
         };
 
         let autocomplete_params = AutocompleteParams {

--- a/src/api/company.rs
+++ b/src/api/company.rs
@@ -155,6 +155,7 @@ mod tests {
 
         let mut base_params = BaseParams::default();
         base_params.pretty = Some(true);
+        base_params.size = Some(1);
 
         let mut search_base_params = SearchBaseParams::default();
         search_base_params.sql =

--- a/src/api/company.rs
+++ b/src/api/company.rs
@@ -155,7 +155,6 @@ mod tests {
 
         let mut base_params = BaseParams::default();
         base_params.pretty = Some(true);
-        base_params.size = Some(1);
 
         let mut search_base_params = SearchBaseParams::default();
         search_base_params.sql =
@@ -170,6 +169,6 @@ mod tests {
         let resp = company.search(search_params).expect("ERROR");
 
         assert_eq!(resp.status, 200);
-        assert_eq!(resp.total, Some(1));
+        assert_eq!(resp.total, Some(2));
     }
 }

--- a/src/api/ip.rs
+++ b/src/api/ip.rs
@@ -33,7 +33,7 @@ mod tests {
         base_params.pretty = Some(true);
 
         let mut ip_base_params = IPBaseParams::default();
-        ip_base_params.ip = Some("72.212.42.169".to_string());
+        ip_base_params.ip = Some("72.212.42.228".to_string());
 
         let ip_params = IPParams {
             base_params: Some(base_params),
@@ -43,6 +43,6 @@ mod tests {
         let resp = ip.get(ip_params).expect("ERROR");
 
         assert_eq!(resp.status, 200);
-        assert_eq!(resp.data.ip.address, "72.212.42.169");
+        assert_eq!(resp.data.ip.address, "72.212.42.228");
     }
 }

--- a/src/models/autocomplete.rs
+++ b/src/models/autocomplete.rs
@@ -13,6 +13,9 @@ pub struct AutocompleteBaseParams {
     /// Setting titlecase to true will titlecase the data in 200 responses
     #[serde(rename = "titlecase", skip_serializing_if = "Option::is_none")]
     pub titlecase: Option<bool>,
+    /// If true, the response will return updated title tags
+    #[serde(rename = "updated_title_roles", default)]
+    pub updated_title_roles: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Description of the change

- Add Updated Title Roles to Autocomplete

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
