### PR TITLE
chore: release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.0] - 2026-07-22
+
+- Added Job Posting API support: new `jobposting` endpoint, `JobPostingApi`, and request/response models
+- Added PDL API v35.0 fields: `technologies_used` on Company, additional IP and Job Posting fields
+- **Breaking:** many `IPInfo`/`IPMetadata`/`IPLocation`/`IPCompany`/`IPCompanyLocation`/`IPPerson` fields changed from required to `Option<T>` to reflect fields the API may omit
+- **Breaking:** `IPPerson.job_title_subrole` now deserializes from `job_title_sub_role`; added `IPPerson.job_title_class` and `IPCompany.display_name`
+- **Breaking:** `JobPosting.location: Option<String>` replaced with `locations: Option<Vec<JobPostingLocation>>`
+- **Breaking:** `JobPosting.salary_range_min`/`salary_range_max` changed from `Option<i32>` to `Option<f64>` and now deserialize from `salary_min`/`salary_max`
+- **Breaking:** `JobPosting.inferred_skills` changed from `Option<Vec<String>>` to `Option<Vec<JobPostingSkill>>`
+- `error.type` fields on Company/Person/Changelog errors now accept either a single string or an array of strings from the API
+
 ## [4.2.0] - 2026-03-18
 
 - Added employee_growth_rate_12_month_by_country to Company model (PDL API v33.2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peopledatalabs"
-version = "4.2.0"
+version = "5.0.0"
 edition = "2021"
 description = "A Rust client for the People Data Labs API"
 documentation = "https://docs.peopledatalabs.com/docs/rust-sdk"


### PR DESCRIPTION
## Summary
- Bump version to 5.0.0
- Add changelog entry covering Job Posting API support (#39) and v35.0 field updates (#41), which include several breaking model changes

## Breaking changes
- Many `IPInfo`/`IPMetadata`/`IPLocation`/`IPCompany`/`IPCompanyLocation`/`IPPerson` fields are now `Option<T>`
- `IPPerson.job_title_subrole` now deserializes from `job_title_sub_role`
- `JobPosting.location: Option<String>` replaced with `locations: Option<Vec<JobPostingLocation>>`
- `JobPosting.salary_range_min`/`salary_range_max` changed from `Option<i32>` to `Option<f64>`
- `JobPosting.inferred_skills` changed from `Option<Vec<String>>` to `Option<Vec<JobPostingSkill>>`

## Test plan
- [x] `cargo build`
- [x] `cargo test` (25 passed)